### PR TITLE
Enhancements for HardwareSerial (Arduino Mega) and ask() with empty s…

### DIFF
--- a/MOVIShield.cpp
+++ b/MOVIShield.cpp
@@ -49,7 +49,7 @@ MOVI::MOVI()
     construct(ARDUINO_RX_PIN, ARDUINO_TX_PIN, false);
 }
 
-MOVI::MOVI(uint8_t debugonoff)
+MOVI::MOVI(bool debugonoff)
 {
     usehardwareserial=false;
     construct(ARDUINO_RX_PIN, ARDUINO_TX_PIN, debugonoff);
@@ -64,11 +64,11 @@ MOVI::MOVI(bool debugonoff, int rx, int tx)
     construct(rx, tx, debugonoff);
 }
 
-MOVI::MOVI(HardwareSerial *hs)
+MOVI::MOVI(bool debugonoff, HardwareSerial *hs)
 {
     usehardwareserial=true;
     mySerial = hs;
-    construct(0, 0, false);
+    construct(0, 0, debugonoff);
 }
 
 // Arduino's' C++ does not allow for constructor overloading!
@@ -88,7 +88,10 @@ void inline MOVI::construct(int rx, int tx, bool debugonoff)
             mySerial=new SoftwareSerial(rx, tx);
         }
     #else
-        mySerial = &Serial1;
+        if (!usehardwareserial) {
+            usehardwareserial = true;
+            mySerial = &Serial1;
+        }
     #endif
 }
 
@@ -445,10 +448,8 @@ bool MOVI::train()
 
 MOVI::~MOVI()
 {
-#ifdef ARDUINO_ARCH_AVR
     if (NULL != mySerial && (!usehardwareserial))
     {
         delete mySerial;
     }
-#endif
 }

--- a/MOVIShield.cpp
+++ b/MOVIShield.cpp
@@ -45,11 +45,13 @@
 
 MOVI::MOVI()
 {
+    usehardwareserial=false;
     construct(ARDUINO_RX_PIN, ARDUINO_TX_PIN, false);
 }
 
-MOVI::MOVI(bool debugonoff)
+MOVI::MOVI(uint8_t debugonoff)
 {
+    usehardwareserial=false;
     construct(ARDUINO_RX_PIN, ARDUINO_TX_PIN, debugonoff);
 }
 
@@ -58,9 +60,16 @@ MOVI::MOVI(bool debugonoff, int rx, int tx)
     #ifndef ARDUINO_ARCH_AVR
     #warning rx and tx parameters only supported in AVR architecture. Using Serial1 hardwired. 
     #endif
+    usehardwareserial=false;
     construct(rx, tx, debugonoff);
 }
 
+MOVI::MOVI(HardwareSerial *hs)
+{
+    usehardwareserial=true;
+    mySerial = hs;
+    construct(0, 0, false);
+}
 
 // Arduino's' C++ does not allow for constructor overloading!
 void inline MOVI::construct(int rx, int tx, bool debugonoff)
@@ -75,7 +84,9 @@ void inline MOVI::construct(int rx, int tx, bool debugonoff)
     callsigntrainok=true;
     
     #ifdef ARDUINO_ARCH_AVR
-        mySerial=new SoftwareSerial(rx, tx);
+        if (!usehardwareserial) {
+            mySerial=new SoftwareSerial(rx, tx);
+        }
     #else
         mySerial = &Serial1;
     #endif
@@ -95,7 +106,18 @@ void MOVI::init(bool waitformovi)
                 ; // wait for serial port to connect. Needed for Leonardo only
            }
         }
-        mySerial->begin(ARDUINO_BAUDRATE);
+       
+#ifdef ARDUINO_ARCH_AVR
+        if (usehardwareserial) ((HardwareSerial *)mySerial)->begin(ARDUINO_BAUDRATE);
+        else ((SoftwareSerial *)mySerial)->begin(ARDUINO_BAUDRATE);
+#elif defined ARDUINO_ARCH_SAM
+        ((USARTClass *)mySerial)->begin(ARDUINO_BAUDRATE);
+#elif defined __ARDUINO_X86__
+        ((TTYUARTClass *)mySerial)->begin(ARDUINO_BAUDRATE);
+#else
+   #error This version of the MOVI API only supports boards with an AVR, SAM or Intel processor.
+#endif
+
         shieldinit=1;
         while (waitformovi && !isReady()) {
             delay(10);
@@ -318,14 +340,14 @@ void MOVI::password(String question, String passkey)
 #ifdef F // check to see if F() macro is available
 void MOVI::ask(const __FlashStringHelper* question)
 {
-    say(question);
+    if (String(question).length() > 0) say(question);
     sendCommand(F("ASK"),F(""));
 }
 #endif
 
 void MOVI::ask(String question)
 {
-    say(question);
+    if (question.length() > 0) say(question);
     sendCommand("ASK","");
 }
 
@@ -424,7 +446,7 @@ bool MOVI::train()
 MOVI::~MOVI()
 {
 #ifdef ARDUINO_ARCH_AVR
-    if (NULL != mySerial)
+    if (NULL != mySerial && (!usehardwareserial))
     {
         delete mySerial;
     }

--- a/MOVIShield.h
+++ b/MOVIShield.h
@@ -116,10 +116,13 @@ public:
     MOVI();
     
     // Construct a MOVI object with optional serial monitor interaction.
-    MOVI(bool debugonoff);
+    MOVI(uint8_t debugonoff);
    
     // Construct a MOVI object with different communication pins and optional serial monitor interaction. This constructor only works on AVR architecture CPU (e.g Arduino Uno, Mega, Leonardo. NOT Due, Zero, Edison)
     MOVI(bool debugonoff, int rx, int tx);
+    
+    // Construct a MOVI object with an existing HardwareSerial (eg. Arduino Mega).
+    MOVI(HardwareSerial *hs);
     
     // init waits for MOVI to be booted and resets some settings. If the recognizer had been stopped with
     // stopDialog() it is restarted.
@@ -257,7 +260,9 @@ private:
     bool firstsentence;    // determines if addSentence() has been called
     void construct(int rx, int tx, bool debugonoff); // workaround for non-functioning constructor overloading
     String passstring;      // stores the passkey for a password() request
+    bool usehardwareserial; // flag to store if we are using AVR SoftwareSerial or HardwareSerial
 
+/*
 #ifdef ARDUINO_ARCH_AVR
     SoftwareSerial *mySerial; // serial communication line as SoftwareSerial for AVR CPUs (Uno, Mega, Leonardo,...)
 #elif defined ARDUINO_ARCH_SAM
@@ -267,6 +272,8 @@ private:
 #else
    #error This version of the MOVI API only supports boards with an AVR, SAM or Intel processor.
 #endif
+*/
+    Stream *mySerial;
     
     String response; // stores the stream of serial communication characters
     String result;   // stores the last result for getResult()

--- a/MOVIShield.h
+++ b/MOVIShield.h
@@ -116,13 +116,13 @@ public:
     MOVI();
     
     // Construct a MOVI object with optional serial monitor interaction.
-    MOVI(uint8_t debugonoff);
+    MOVI(bool debugonoff);
    
     // Construct a MOVI object with different communication pins and optional serial monitor interaction. This constructor only works on AVR architecture CPU (e.g Arduino Uno, Mega, Leonardo. NOT Due, Zero, Edison)
     MOVI(bool debugonoff, int rx, int tx);
     
     // Construct a MOVI object with an existing HardwareSerial (eg. Arduino Mega).
-    MOVI(HardwareSerial *hs);
+    MOVI(bool debugonoff, HardwareSerial *hs);
     
     // init waits for MOVI to be booted and resets some settings. If the recognizer had been stopped with
     // stopDialog() it is restarted.
@@ -262,17 +262,6 @@ private:
     String passstring;      // stores the passkey for a password() request
     bool usehardwareserial; // flag to store if we are using AVR SoftwareSerial or HardwareSerial
 
-/*
-#ifdef ARDUINO_ARCH_AVR
-    SoftwareSerial *mySerial; // serial communication line as SoftwareSerial for AVR CPUs (Uno, Mega, Leonardo,...)
-#elif defined ARDUINO_ARCH_SAM
-    USARTClass *mySerial; // serial communication line as USARTClass for SAM CPUs (Due, Zero)
-#elif defined __ARDUINO_X86__
-    TTYUARTClass *mySerial; // serial communication line as TTYUARTClass for Intel CPUs (Galileo, Edison)
-#else
-   #error This version of the MOVI API only supports boards with an AVR, SAM or Intel processor.
-#endif
-*/
     Stream *mySerial;
     
     String response; // stores the stream of serial communication characters


### PR DESCRIPTION
Based on MOVI API 1.03, these changes allow for construction of MOVI()
using a HardwareSerial pointer.  Also included is a small change to
prevent ask() from calling say() when the parameter is an empty string.
