### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MOVI Voice Dialog Shield
-version=1.2.00
+version=1.2.0
 author=Audeme LLC
 maintainer=Gerald Friedland <fractor@audeme.com>
 sentence=This is the Arduino library for the MOVI(tm) Voice Dialog Shield for speech synthesis and speech recognition on Arduino boards.


### PR DESCRIPTION
The previous `version` value caused the Arduino IDE to repeatedly display warnings:
```
Invalid version '1.2.00' for library in: {library installation path}
```
This warning can be especially confusing for users since older versions of the Arduino IDE doesn't say which library is the source of the problem.

Installing a library with an invalid `version` causes Arduino IDE 1.8.6 to no longer start.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format